### PR TITLE
DAG Grupo 3 - JCSP

### DIFF
--- a/archivo_subido.txt
+++ b/archivo_subido.txt
@@ -1,0 +1,1 @@
+AT: my second sample

--- a/dags/g3_jcsp.py
+++ b/dags/g3_jcsp.py
@@ -1,0 +1,39 @@
+from airflow.decorators import dag, task
+from pendulum import timezone
+from scripts.azure_upload import upload_to_adls
+from scripts.helpers import add_date_suffix
+from datetime import datetime, timedelta
+
+LOCAL_FILE_PATH = "/opt/airflow/data/sample.txt"
+CONTAINER_NAME = "airflow"
+BLOB_NAME = "raw/g3/archivo_subido.txt"
+
+default_args = {
+    'owner': 'airflow',
+    'retries': 1,
+    'retry_delay': timedelta(minutes=1),
+}
+
+@dag(
+    dag_id="g3_jcsp",
+    description="Uploads a local file to Azure Blob Storage with a date suffix.",
+    default_args=default_args,
+    start_date=datetime(2025, 1, 1, tzinfo=timezone("America/Bogota")),
+    schedule="0 12 * * 1", # Runs every monday at 12:00 local time (GMT-5)
+    catchup=False,
+    tags=["azure", "blob", "upload"],
+)
+def upload_dag():
+
+    @task
+    def call_upload():
+        new_blob_name = add_date_suffix(BLOB_NAME)
+        upload_to_adls(
+            local_file_path=LOCAL_FILE_PATH,
+            container_name=CONTAINER_NAME,
+            blob_name=new_blob_name
+            )
+
+    call_upload()
+
+dag = upload_dag()


### PR DESCRIPTION
El DAG en Airflow, identificado con el nombre único "g3_jcsp", está diseñado para automatizar de forma confiable y programada la carga de un archivo local ubicado en /opt/airflow/data/sample.txt hacia Azure Data Lake Storage Gen2 (ADLS), específicamente en el contenedor airflow bajo la ruta raw/g3/, cada lunes a las 12:00 hora local de Perú (GMT-5). Antes de realizar la subida, se ejecuta una función auxiliar que agrega un sufijo de fecha al nombre del archivo (por ejemplo, archivo_subido_20250401.txt), garantizando que cada ejecución genere un archivo único y versionado, evitando sobrescrituras y facilitando el seguimiento histórico de datos. El flujo está compuesto por una única tarea definida con el decorador @task, que encapsula la lógica completa de generación del nombre y la llamada a la función de subida a Azure. El DAG tiene configurada una fecha de inicio del 1 de enero de 2025 y está programado con un intervalo semanal mediante una expresión cron (0 12 * * 1), con la opción catchup=False para evitar ejecuciones retroactivas. Además, incluye configuraciones de robustez mediante default_args: el propietario es airflow, se permite 1 reintento en caso de fallo, con una espera de 1 minuto entre intentos, y está etiquetado con los tags "azure", "blob" y "upload" para una mejor organización, visibilidad y filtrado en la interfaz gráfica de Airflow. En resumen, es un flujo de trabajo simple, eficiente, tolerante a fallos y orientado al versionado de datos en la nube.