### PR TITLE
DAG Grupo 5 - RRM

### DIFF
--- a/dags/g5_rrm.py
+++ b/dags/g5_rrm.py
@@ -1,0 +1,42 @@
+from airflow.decorators import dag, task
+from pendulum import timezone
+from scripts.azure_upload import upload_to_adls
+from scripts.helpers import add_date_suffix
+from datetime import datetime, timedelta
+
+LOCAL_FILE_PATH = "/opt/airflow/data/sample.txt"
+CONTAINER_NAME = "datalake"
+WASB_CONN_ID = "utec_blob_storage"
+BLOB_NAME = "raw/G5/archivo_subido.txt"
+
+default_args = {
+    "owner": "airflow",
+    "retries": 1,
+    "retry_delay": timedelta(minutes=1),
+}
+
+
+@dag(
+    dag_id="g5_rrm",
+    description="Uploads a local file to Azure Blob Storage with a date suffix.",
+    default_args=default_args,
+    start_date=datetime(2025, 1, 1, tzinfo=timezone("America/Bogota")),
+    schedule="0 12 * * 1",
+    catchup=False,
+    tags=["g5", "azure", "blob", "upload"],
+)
+def upload_dag():
+    @task
+    def call_upload():
+        new_blob_name = add_date_suffix(BLOB_NAME)
+        upload_to_adls(
+            local_file_path=LOCAL_FILE_PATH,
+            container_name=CONTAINER_NAME,
+            blob_name=new_blob_name,
+            wasb_conn_id=WASB_CONN_ID,
+        )
+
+    call_upload()
+
+
+dag = upload_dag()


### PR DESCRIPTION
## Resumen
Este PR agrega el DAG del Grupo 5 usando el flujo `g5_rrm`.

## Cambios realizados
- Se agregó el archivo `dags/g5_rrm.py`
- Se configuró la carga del archivo `/opt/airflow/data/sample.txt`
- Se configuró la ruta de destino en Azure como `raw/G5/archivo_subido.txt`
- Se definió un `dag_id` único para evitar conflictos con otros grupos

## Notas
- Branch usado para esta implementación: `feature/dag-g5-RRM`
- Conexión de Airflow utilizada: `utec_blob_storage`
- Contenedor de Azure utilizado: `datalake`